### PR TITLE
Issue #403 (Add a line of explanation when a wrong answer is given in the quiz.)

### DIFF
--- a/question.js
+++ b/question.js
@@ -9,7 +9,8 @@ let questions = [
       "DHRIHASTARA",
       "ARJUN",
       "KRISHNA"
-    ]
+    ],
+    inf:"DHRIHASTARA became king in Hastināpura after Pāṇḍu retired to the forest. He was the father of the Kauravas."
   },
   {
     numb: 2,
@@ -20,7 +21,8 @@ let questions = [
       "ARJUNA",
       "YUYUDHANA",
       "DURYODHANA"
-    ]
+    ],
+    inf:"DURYODHANA was the leader of the Kauravas. From childhood he formed an enmity with the Pāṇḍavas, which later resulted in the Kurukṣetra war."
   },
   {
     numb: 3,
@@ -31,7 +33,8 @@ let questions = [
       "5",
       "2",
       "100"
-    ]
+    ],
+    inf:"Pāṇḍu reconciled himself to the fact that he would have only FIVE sons, but he was not disappointed. His boys grew up like gods.-MAHABHARATA"
   },
   {
     numb: 4,
@@ -42,7 +45,8 @@ let questions = [
       "Arjuna",
       "Brahman",
       "Shudra"
-    ]
+    ],
+    inf:"The KSHATRIYAS are administrators, so they rule over the country. They exact taxes from the citizens."
   },
   {
     numb: 5,
@@ -53,7 +57,8 @@ let questions = [
       "BHISHMA",
       "ARJUNA",
       "KRISHNA"
-    ]
+    ],
+    inf:"In verse 18.17 the Lord informs ARJUNA that the desire not to fight arises from false ego. Arjuna thought himself to be the doer of action, but he did not consider the supreme sanction within"
   },
   {
     numb: 6,
@@ -63,7 +68,8 @@ let questions = [
       "Song of the Lord",
       "Song of Happiness",
       "God's past times",
-      "Song of the Universe"]
+      "Song of the Universe"],
+      inf:"The Bhagavad-gītā, THE SONG OF THE EXALTED GOD, is a very ancient philosophical, didactic"
   },
   {
     numb: 7,
@@ -73,7 +79,8 @@ let questions = [
       "Dhritarashtra's advisor",
       "Arjuna's cousin",
       "Arjuna's advisor",
-      "Duryodhana's brother"]
+      "Duryodhana's brother"],
+      inf:"SANJAYA was Dhṛtarāṣṭra's charioteer and secretary. Although he belonged to the suta caste, he was a spiritually advanced disciple of Vyāsadeva, who gave him the power to see the events during the Kurukṣetra war. "
   },
   {
     numb: 8,
@@ -83,7 +90,8 @@ let questions = [
       "Vrindaavan",
       "Kurukshetra",
       "Mathura",
-      "Ayodhya"]
+      "Ayodhya"],
+      inf:" Said by the Vedas to be God, the Supreme Person, who is the origin of all other incarnations He spoke the Bhagavad-gita to Arjuna at the beginning of the KURUKSHETRA war."
   },
   {
     numb: 9,
@@ -93,7 +101,8 @@ let questions = [
       "18",
       "16",
       "20",
-      "22"]
+      "22"],
+      inf:"A total of 18 chapters are present in the Gita"
   },
   {
     numb: 10,
@@ -103,7 +112,8 @@ let questions = [
       "Lord Krishna",
       "Lord Shiva",
       "Lord Vishnu",
-      "Lord Brahma"]
+      "Lord Brahma"],
+      inf:"The Bhagavad-gītā also should be accepted as it is directly by the speaker Himself. The speaker is Lord ŚRI KRISHNA."
   },
   {
     numb: 11,
@@ -113,7 +123,9 @@ let questions = [
       "Rajas",
       "Tamas",
       "Sattva",
-      "None of the above"]
+      "None of the above"],
+      inf:"RAJAS-guṇa is passion, and tamo-guṇa is darkness."
+      
   },
   {
     numb: 12,
@@ -123,7 +135,8 @@ let questions = [
       "Chasing after money",
       "Meditating in an ashram",
       "Dedication your actions to the Lord",
-      "Sacrificing something"]
+      "Sacrificing something"],
+      inf:"Ordinary work is karma. And when it is added with yoga, that means spiritualized work.Yoga means spiritual perfection, or linking up with the Supreme."
   },
   {
     numb: 13,
@@ -134,7 +147,8 @@ let questions = [
       "Destruction of family traditions",
       "Fear of sinful reactions",
       "Fear of losing the battle",
-    ]
+    ], 
+    inf:"Both as friend and philosopher to Arjuna, Lord Kṛiṣhṇa  gave His final judgment regarding Arjuna's The Lord says, “Arjuna, if you leave the battlefield before the battle even begins, people will call , then My advice is that you'd do better to die in the battle. So, you should not flee for fear of your life; better to die in the battle.“"
   },
   {
     numb: 14,
@@ -144,7 +158,8 @@ let questions = [
       "Hanuman",
       "Ganesha",
       "Krishna",
-      "Sun"]
+      "Sun"],
+      inf:"The emblem of HANUMAN on the flag of Arjuna is another sign of victory because Hanuman cooperated with Now both Rāma and Hanumān were present on the chariot of Arjuna to help him. Lord Kṛṣṇa is Rāma Himself, and wherever Lord Rāma is, His eternal servitor Hanuman is."
   },
   {
     numb: 15,
@@ -154,7 +169,8 @@ let questions = [
       "Uncontrolled senses",
       "Uncertainty of the future",
       "Forgetfulness of Lord Krishna",
-      "Lack of intelligence"]
+      "Lack of intelligence"],
+      inf:"The real cause of his difficulties in the hard struggle for life may be found in his FORGETFULNESS of his relationship with the Supreme Lord.-GITA VERSE 5.17-25"
   },
   {
     numb: 16,
@@ -164,7 +180,8 @@ let questions = [
       "King Pandu",
       "Dhritarashtra",
       "King Gandhar",
-      "Jarasandha"]
+      "Jarasandha"],
+      inf:"PANDU was the Father of the Pāṇḍavas born to Vicitravīrya's widow queen Ambālikā by the grace of Vyāsadeva."
   },
   {
     numb: 17,
@@ -174,7 +191,8 @@ let questions = [
       "The Moon",
       "Jupiter",
       "The Sun",
-      "Mars"]
+      "Mars"],
+      inf:"KARNA was the firstborn son of the Pāṇḍavas's mother Kuntī from her union with the SUN-GOD. He became the chief support and best friend of Duryodhana, who made him king of Aṅga. He was killed by Arjuna at Kurukṣetra and went to the sun planet."
   },
   {
     numb: 18,
@@ -184,7 +202,8 @@ let questions = [
       "Ved Vyas",
       "Valmiki",
       "Durvas Rishi",
-      "Krupacharya"]
+      "Krupacharya"],
+      inf:"VYASA was the sage who authored the Mahābhārata. Born from the union of Parāśara Ṛṣi and Satyavatī, he is known as Dwaipayana because he was born on an island. He compiled the Vedas."
   },
   {
     numb: 19,
@@ -194,7 +213,8 @@ let questions = [
       "Karna",
       "Arjuna",
       "Devabrata",
-      "Pallove"]
+      "Pallove"],
+      inf:"BHISHMA was the son of Śantanu, known as the “grandfather” of the Kurus. Although he never became king, he officiated at Hastināpura as regent until Vicitravīrya was of age."
   },
   {
     numb: 20,
@@ -204,7 +224,8 @@ let questions = [
       "Gandharva Kingdom",
       "The Kauravas",
       "The Pandavas",
-      " Magadha Kingdom"]
+      " Magadha Kingdom"],
+      inf:"The PANDAVAS won the battle of Kurukshetra.Those heroic men lived only for Kṛiṣhṇa's pleasure, and the universe itself depends on His will."
   },
   {
     numb: 21,
@@ -215,7 +236,8 @@ let questions = [
       "Kashi",
       "Ayodhya",
       "Dwarka"
-    ]
+    ],
+    inf:"It is a conversation between the Lord and the devotee. Arjuna is a devotee, and Kṛṣṇa is the Supreme Personality of Godhead. It took place in KURUKSHETRA."
   },
   {
     numb: 22,
@@ -226,7 +248,8 @@ let questions = [
       "Karma Yoga (path of selfless action)",
       "Jnana Yoga (path of knowledge)",
       "All of the above"
-    ]
+    ],
+    inf:"The paths of yoga are karma, jñāna and bhakti—but everything is leading to bhakti. When karma leads to bhakti, that is called karma-yoga. When jñāna leads to bhakti, that is called jñāna-yoga. Yoga means bhakti-yoga, as it is stated in the Bhagavad-gītā."
   },
   {
     numb: 23,
@@ -237,7 +260,8 @@ let questions = [
       "The soul is eternal and indestructible",
       "The soul doesn't exist",
       "The soul is an illusion"
-    ]
+    ],
+    inf:"O Pārtha, how can a person who knows that the soul is indestructible, eternal, unborn and immutable kill.-Gita"
   },
   {
     numb: 24,
@@ -248,7 +272,8 @@ let questions = [
       "Pleasure and enjoyment",
       "Enlightenment and liberation",
       "Fame and recognition"
-    ]
+    ],
+    inf:"So this liberation should be the ultimate goal of life.-Gita"
   },
   {
     numb: 25,
@@ -259,6 +284,7 @@ let questions = [
       "Do your duty without attachment to the results",
       "Know that I am the eternal soul within all beings.",
       "Renounce all desires and attain liberation"
-    ]
+    ],
+    inf:"One who performs his duty without attachment, surrendering the results unto the Supreme Lord, is unaffected.- Gita"
   },
 ];

--- a/question.js
+++ b/question.js
@@ -148,7 +148,7 @@ let questions = [
       "Fear of sinful reactions",
       "Fear of losing the battle",
     ], 
-    inf:"Both as friend and philosopher to Arjuna, Lord Kṛiṣhṇa  gave His final judgment regarding Arjuna's The Lord says, “Arjuna, if you leave the battlefield before the battle even begins, people will call , then My advice is that you'd do better to die in the battle. So, you should not flee for fear of your life; better to die in the battle.“"
+    inf:"Both as friend and philosopher to Arjuna, Lord Kṛiṣhṇa  gave His final judgment regarding Arjuna's fear. The Lord says, “Arjuna, if you leave the battlefield before the battle even begins, people will call , then My advice is that you'd do better to die in the battle. So, you should not flee for fear of your life; better to die in the battle.“"
   },
   {
     numb: 14,

--- a/quiz_page/quiz.html
+++ b/quiz_page/quiz.html
@@ -89,6 +89,10 @@
             <div class="option_list">
                 
             </div>
+
+            <div class="info">
+              
+            </div>
         </section>
        
         <footer>

--- a/quiz_page/quiz.js
+++ b/quiz_page/quiz.js
@@ -10,7 +10,7 @@ const option_list = document.querySelector(".option_list");
 const time_line = document.querySelector("header .time_line");
 const timeText = document.querySelector(".timer .time_left_txt");
 const timeCount = document.querySelector(".timer .timer_sec");
-
+const infm=quiz_box.querySelector(".info");
 start_btn.onclick = ()=>{
     info_box.classList.add("activeInfo");
 }
@@ -78,6 +78,7 @@ next_btn.onclick = ()=>{
         clearInterval(counterLine);
         showResult();
     }
+    infm.innerHTML="";
 }
 
 function showQuetions(index){ 
@@ -107,6 +108,7 @@ function optionSelected(answer){
     let userAns = answer.textContent; 
     let correcAns = questions[que_count].answer; 
     const allOptions = option_list.children.length; 
+    let infor=questions[que_count].inf; 
     
     if(userAns == correcAns){ 
         userScore += 1; 
@@ -123,6 +125,7 @@ function optionSelected(answer){
                 option_list.children[i].setAttribute("class", "option correct"); 
                 option_list.children[i].insertAdjacentHTML("beforeend", tickIconTag); 
                 console.log("Auto selected correct answer.");
+                infm.innerHTML=infor;
             }
         }
     }


### PR DESCRIPTION
FILES CHANGED: quiz.html, quiz.js, questions.js

SUMMARY: The quiz now displays short explanations for the answer, if an incorrect response is received. 
All the information has been taken from vedabase.io

SCREENSHOTS
**IN CASE OF WRONG ANSWER (LINE OF EXPLANATION ADDED)**
![Bhagwad Gita Quiz - Google Chrome 5_26_2023 11_24_19 PM](https://github.com/akshitagupta15june/Moksh/assets/87938552/6a15b2f8-e7d3-4022-8105-de6dad5f15ce)

![Bhagwad Gita Quiz - Google Chrome 5_26_2023 11_24_36 PM](https://github.com/akshitagupta15june/Moksh/assets/87938552/1412acc3-715b-4f69-92c7-5edc3800602a)

**IN CASE OF CORRECT ANSWER (NO CHANGE)**
![Bhagwad Gita Quiz - Google Chrome 5_26_2023 11_24_46 PM](https://github.com/akshitagupta15june/Moksh/assets/87938552/5d70393e-ea49-47c0-b88e-3149cbf63115)

