### PR TITLE
fix: attached event.css

### DIFF
--- a/Iskcon/event.html
+++ b/Iskcon/event.html
@@ -9,6 +9,7 @@
     <title>Iskcon Events</title>
     <link rel="icon" type="image/x-icon" href="../Images/logoBgRemoved.webp" />
     <link rel="stylesheet" href="../commonStyles.css">
+    <link rel="stylesheet" href="../Iskcon/event.css">
 
   </head>
 


### PR DESCRIPTION
Closes: #1145 
event.css file is already present in the iskcon folder but not linked with html file.
<img width="960" alt="image" src="https://github.com/akshitagupta15june/Moksh/assets/100852245/4a507fa5-5059-434c-97cf-b9eaf1b8d271">
Now, the cards get popped up better on clicking.
<img width="960" alt="image" src="https://github.com/akshitagupta15june/Moksh/assets/100852245/dae45e61-bc47-4ccc-a9aa-5dee040713af">
<img width="960" alt="image" src="https://github.com/akshitagupta15june/Moksh/assets/100852245/3e5f06ab-b9fb-48d6-aaad-c707318fdfc5">

