### PR TITLE
Fixed image bug for 541px to 767px

### DIFF
--- a/Gita-Storyline/storyline.css
+++ b/Gita-Storyline/storyline.css
@@ -176,20 +176,20 @@ background-size: cover;
     }
 }
 
-@media only screen and (min-width : 550px) and (max-width: 767px) {
+@media only screen and (min-width : 541px) and (max-width: 767px) {
     #arjuna-image,
     #krishna-image {
-        top: calc(50% + 40%); /* Adjust the top position for smaller screens */
+        top: calc(30% + 50%); /* Adjust the top position for smaller screens */
         width: 23%; /* Increase the size of arjuna and krishna by 5% */
     }
 
     #krishna-image {
-        top: 85%; /* Move the krishna image top by 15% */
+        top: 70%; /* Move the krishna image top by 15% */
         left: 65%; /* Move the krishna image right by 15% */
     }
 
     #arjuna-image {
-        top: 85%; /* Move the krishna image top by 15% */
+        top: 70%; /* Move the krishna image top by 15% */
         left: 12%; /* Move the krishna image right by 15% */
     }
 
@@ -203,10 +203,12 @@ background-size: cover;
     }
 
     #left-arrow {
+        top:70%;
         left: 5%; /* Move the left arrow more left */
     }
 
     #right-arrow {
+        top:70%;
         right: 5%; /* Move the right arrow more right */
     }
 }
@@ -215,8 +217,8 @@ background-size: cover;
     height: auto;
     width: 20rem;
     position: relative;
-    bottom: 35rem;
-    left: 21%; /* Center the box horizontally */
+    bottom: 40rem;
+    left: 25%; /* Center the box horizontally */
     transform: translateX(-50%); /* Center the box horizontally */
     text-align: center;
     overflow-y: auto;
@@ -229,7 +231,7 @@ background-size: cover;
     height: 7rem;
     width: 20rem; /* Adjust width as needed */
     position: relative;
-    bottom: 50rem;
+    bottom: 54rem;
     left: 71%; /* Center the box horizontally */
     transform: translateX(-50%); /* Center the box horizontally */
     text-align: center;
@@ -267,6 +269,30 @@ background-size: cover;
 }
 
 
+@media screen and (min-width: 541px) and (max-width: 767px) {
+    #arjuna-conversation {
+        background-color: antiquewhite;
+        height: 7rem;
+        width: 14rem;
+        position: relative;
+        bottom: 42rem;
+        transform: translateX(-50%);
+        text-align: center;
+        overflow-y: auto;
+        padding: 18px;
+    }
+    #krishna-conversation {
+        background-color: antiquewhite;
+        height: 7rem;
+        width: 18rem;
+        position: relative;
+        bottom: 55rem;
+        transform: translateX(-50%); 
+        text-align: center;
+        overflow-y: auto;
+        padding: 18px;
+    }
+}
 @media screen and (min-width: 768px) and (max-width: 912px) {
     #arjuna-conversation {
         background-color: antiquewhite;
@@ -310,6 +336,7 @@ background-size: cover;
     position: absolute;
     bottom: 2%;
     left: 1%;
+    z-index: 99;
 }
 #play:hover,
 #pause:hover {


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1419 


## Description

Since the Gita Storyline page had issue with image overlapping and overflowing, I resolved it using media query for different images on screen size of 541px to 767px.

## Screenshots

<img width="473" alt="Screenshot 2023-12-08 101505" src="https://github.com/akshitagupta15june/Moksh/assets/114601400/e5d2d484-ba16-4066-bdb0-cddb089e5aaa">
<img width="444" alt="Screenshot 2023-12-08 101527" src="https://github.com/akshitagupta15june/Moksh/assets/114601400/24d78437-a667-44e1-8b4d-9287ce8c7afe">


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [ x] My code adheres to the established style guidelines of the project.
- [' '] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
