### PR TITLE
Fix broken hyperlink in storyline.html

### DIFF
--- a/Gita-Storyline/storyline.html
+++ b/Gita-Storyline/storyline.html
@@ -177,7 +177,7 @@
               </li>
               <li>
                 <a
-                  href="/Gita-Storyline/storyline.html"
+                  href="storyline.html"
                   class="relative pt-5 pb-1 font-semibold after:content-[''] after:bottom-0 after:h-1 after:w-0 after:left-0 after:absolute after:bg-indigo-600 hover:after:w-full after:ease-in-out after:duration-300"
                   >Gita StoryLine</a
                 >


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1397 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

In this pull request, I have addressed the issue where clicking on the "Gita Storyline" option on the Moksh website was resulting in a 404 error being displayed on the same page. To resolve this, I have made changes to the routing logic to ensure that the correct page is displayed when the "Gita Storyline" option is clicked. This fix should now correctly navigate users to the relevant page without encountering any errors.

## Screenshots

![msedge_KNaCKfLpfy](https://github.com/akshitagupta15june/Moksh/assets/90828823/6fc61da5-5ca1-40d5-96be-ed931aa6c2f9)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
