### PR TITLE
fix: initial tweet click contains quote and author

### DIFF
--- a/shlok_page/motivation.js
+++ b/shlok_page/motivation.js
@@ -190,10 +190,19 @@ const authorBack = authors[1];
 
 const buttonFront = button[0];
 const buttonBack = button[1];
-let quote = '';
-let author = '';
+
+//Initialize quote and author to be same as the one in html
+let quote = 'For the soul there is neither birth nor death at any time. He has not come into being, does not come into being, and will not come into being. He is unborn, eternal, ever-existing, and primeval. He is not slain when the body is slain.';
+let author = '- Lord Sri Krishna - Bhagavad-gita 2.20';
+
 const genQuote = () => {
   var randNum = Math.floor(Math.random() * quotes.length);
+
+  // Preventing repeating the same quote
+  while (quote === quotes[randNum].text) {
+    randNum = Math.floor(Math.random() * quotes.length);
+  }
+
   // Stores the quote present at the randomly generated index
   quote = quotes[randNum].text;
 


### PR DESCRIPTION
## Tweet button under Gita shlok generator does not paste correct text on Twitter

Closes: #1545 

## Description

The initial problem was that when the page renders and the first shlok shows up, upon clicking the tweet button, we'd be redirected to Twitter but the quote and author would be empty.

Upon going through the code, I saw we're using inner HTML actions such as onclick directly within the necessary tags. In the tweet button, we're calling the tweetQuote function but when the javascript file is loaded, we've initialized the quote and author to be empty. This is why when we want to tweet the first quote, the initial quote is empty on thw twitter prompt.

The fix for this was to simply initialize the quote and author with the same as the one being loaded in the HTML initially. Along with this, I also added a check in the genQuote function to prevent repeating of the same quote. One thing to note is that some quotes are repeated in the array itself. Other than that, the same quote shouldn't render.

## Screenshots

### 1. First quote:

![image](https://github.com/akshitagupta15june/Moksh/assets/74096450/e57624b8-3cf0-45f7-8465-20e832faa36e)

### 2. After pressing the tweet button:

![image](https://github.com/akshitagupta15june/Moksh/assets/74096450/6e246c62-a8c8-4b5c-b573-5d094d53408d)


## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
