### PR TITLE
[BUG] Mobile Interface Issue: Overlapping 'New Quote' Button in Shlokas Tab #1524

### DIFF
--- a/shlok_page/motivation.css
+++ b/shlok_page/motivation.css
@@ -175,16 +175,16 @@ p:hover {
 
 .text {
   /* font-family: 'krishna','yuvasanskrit','Open Sans Condensed', sans-serif; */
-  font-size: 2rem;
+  font-size: 1.5rem;
   /* font-weight: 600; */
-  padding-left: 10px;
+  padding-left: 10%;
   transition: 0.5s;
   transition-timing-function: ease-in;
   /* font-family: 'laila','Roboto', sans-serif; */
   color: #050350;
   -webkit-background-clip: text;
   font-family: "Laila", serif;
-  font-weight: 500;
+  font-weight: 2%;
   font-style: normal;
 }
 


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes: #1524 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description



In the Shlokas tab on mobile, clicking 'Read' generates a random shloka, but the 'New Quote' button overlaps with the background, obscuring the verse's source. This impedes user understanding and navigation.

To address this issue, I modified the CSS styling in the `shlokas_page/motivation.css` file. Specifically, I adjusted the `.text` class by changing the `font-size` property from `2rem` to `1.5rem`. This change reduces the font size, ensuring that the 'New Quote' button no longer overlaps with the background, improving the readability and layout of the shloka's source.


## Screenshots
[Screenshot of the issue]  

![WhatsApp Image 2024-05-27 at 21 05 17_bd2f3976](https://github.com/akshitagupta15june/Moksh/assets/146753809/af03e54a-acd2-4354-940b-40f4fb361335)

[Screenshot of the solution]   


![WhatsApp Image 2024-05-28 at 00 22 33_e03eb2ea](https://github.com/akshitagupta15june/Moksh/assets/146753809/d2c7e905-5c6e-4475-8956-106af759c31e)




<!-- Add screenshots to preview the changes  -->

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
